### PR TITLE
Improve styling documentation

### DIFF
--- a/vaadin-dialog.html
+++ b/vaadin-dialog.html
@@ -69,8 +69,12 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * ### Styling
        *
-       * See <vaadin-overlay>'s styling documentation for themable parts but use
-       * theme-for="vaadin-dialog-overlay" to target <vaadin-dialog>'s overlay
+       * The following shadow DOM parts are available for styling:
+       *
+       * Part name | Description | Theme for Element
+       * ----------------|----------------|----------------
+       * `backdrop` | Backdrop of the overlay | vaadin-dialog-overlay
+       * `content` | Content of the overlay | vaadin-dialog-overlay
        *
        * @memberof Vaadin
        * @demo demo/index.html


### PR DESCRIPTION
The previous documentation said "See `<vaadin-overlay>`'s styling documentation for themable parts". However, there is no styling documentation for `<vaadin-overlay>` and since it's an element for internal use anyway, it's a bad reference for docs.

List the shadow parts in `<vaadin-dialog>`'s documentation instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog/4)
<!-- Reviewable:end -->
