### PR TITLE
Fix/enable ie11 tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,6 @@
     "iron-demo-helpers": "^2.0.0",
     "iron-test-helpers": "^2.0.0",
     "vaadin-button": "^1.0.0",
-    "web-component-tester": "^6.0.0"
+    "web-component-tester": "^6.1.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7959,8 +7959,8 @@
       }
     },
     "web-component-tester": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.0.1.tgz",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.1.5.tgz",
       "integrity": "sha512-viy1V/XAbkuDP6N0EZWmyBvfeZwQXEfnzSZs66ur/8iu07QBHsp9lIAFlUswfsEkUHMQHqiuncsp7EA5AgCDvA==",
       "dev": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "polymer-cli": "^1.2.0",
     "stylelint": "^8.0.0",
     "stylelint-config-vaadin": "latest",
-    "web-component-tester": "^6.0.0",
+    "web-component-tester": "^6.1.5",
     "yargs": "latest"
   },
   "greenkeeper": {

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -6,7 +6,7 @@ module.exports = {
       'macOS 10.12/iphone@10.3',
       'macOS 10.12/ipad@10.3',
       'Windows 10/microsoftedge@15',
-      // 'Windows 10/internet explorer@11',
+      'Windows 10/internet explorer@11',
       'macOS 10.12/safari@10.0'
     ];
 


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-core/issues/127

Bump web-component-tester to 6.1.5 and enable IE tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog/15)
<!-- Reviewable:end -->
