### PR TITLE
Added missing template tag and polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@
 <!--
 ```
 <custom-element-demo>
-  <link rel="import" href="vaadin-dialog.html">
-  <next-code-block></next-code-block>
+  <template>
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="vaadin-dialog.html">
+    <next-code-block></next-code-block>
+  </template>
 </custom-element-demo>
 ```
 -->


### PR DESCRIPTION
There was a missing pair of template tag inside custom-element-demo in order for the inline demo to work. I also added polyfill so the demo can work on non-native-polyfill browsers as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog/29)
<!-- Reviewable:end -->
