### PR TITLE
Send `key` in keyboard events, because it is used in overlay

### DIFF
--- a/test/vaadin-dialog_test.html
+++ b/test/vaadin-dialog_test.html
@@ -35,13 +35,13 @@
 
       describe('no-close-on-esc', () => {
         it('should close itself on ESC press by default', () => {
-          MockInteractions.pressAndReleaseKeyOn(document.body, 27);
+          MockInteractions.pressAndReleaseKeyOn(document.body, 27, [], 'Escape');
           expect(dialog.opened).to.eql(false);
         });
 
         it('should not close itself on ESC press when no-close-on-esc is true', () => {
           dialog.noCloseOnEsc = true;
-          MockInteractions.pressAndReleaseKeyOn(document.body, 27);
+          MockInteractions.pressAndReleaseKeyOn(document.body, 27, [], 'Escape');
           expect(dialog.opened).to.eql(true);
         });
       });


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog/33)
<!-- Reviewable:end -->
