### PR TITLE
Add tests for data binding, remove unused instanceProps

### DIFF
--- a/src/vaadin-dialog.html
+++ b/src/vaadin-dialog.html
@@ -132,10 +132,6 @@ This program is available under Apache License Version 2.0, available at https:/
             }
 
             const Templatizer = Polymer.Templatize.templatize(this._contentTemplate, this, {
-              instanceProps: {
-                detail: true,
-                target: true
-              },
               forwardHostProp: function(prop, value) {
                 if (this._instance) {
                   this._instance.forwardHostProp(prop, value);

--- a/test/vaadin-dialog_test.html
+++ b/test/vaadin-dialog_test.html
@@ -26,6 +26,39 @@
     </template>
   </test-fixture>
 
+  <dom-module id="x-dialog">
+    <template>
+      <vaadin-dialog id="dialog">
+        <template>
+          <span>[[message]]</span>
+          <input value="{{text::input}}">
+        </template>
+      </vaadin-dialog>
+    </template>
+    <script>
+      window.addEventListener('WebComponentsReady', function() {
+        class XDialog extends Polymer.Element {
+          static get is() {
+            return 'x-dialog';
+          }
+          static get properties() {
+            return {
+              message: String,
+              text: String
+            };
+          }
+        }
+        window.customElements.define(XDialog.is, XDialog);
+      });
+    </script>
+  </dom-module>
+
+  <test-fixture id="binding">
+    <template>
+      <x-dialog></x-dialog>
+    </template>
+  </test-fixture>
+
   <script>
     describe('vaadin-dialog', () => {
       var dialog, backdrop, overlay;
@@ -79,6 +112,29 @@
       it('should not throw an exception if template is not present', () => {
         const openDialog = () => dialog.opened = true;
         expect(openDialog).to.not.throw();
+      });
+    });
+
+    describe('vaadin-dialog data binding', () => {
+      let container, dialog, overlay;
+
+      beforeEach(() => {
+        container = fixture('binding');
+        dialog = container.$.dialog;
+        overlay = dialog.$.overlay;
+        dialog.opened = true;
+      });
+
+      it('dialog should bind parent property', () => {
+        container.message = 'foo';
+        expect(overlay.shadowRoot.querySelector('span').textContent.trim()).to.equal('foo');
+      });
+
+      it('dialog should support two-way data binding', () => {
+        const input = overlay.shadowRoot.querySelector('input');
+        input.value = 'bar';
+        input.dispatchEvent(new CustomEvent('input'));
+        expect(container.text).to.equal('bar');
       });
     });
   </script>


### PR DESCRIPTION
We apparently have copy-pasted Templatizer code from the `vaadin-context-menu` in several components, including this one. These `instanceProps` (see the [context-menu API docs](https://github.com/vaadin/vaadin-context-menu/blob/master/src/vaadin-context-menu.html#L166)) do not make any sense here and should be removed.

Also added the tests for data binding, based on vaadin/vaadin-notification#54

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog/58)
<!-- Reviewable:end -->
