### PR TITLE
Adjust for optical vertical centering

### DIFF
--- a/theme/lumo/vaadin-dialog.html
+++ b/theme/lumo/vaadin-dialog.html
@@ -4,11 +4,15 @@
 <dom-module id="lumo-dialog" theme-for="vaadin-dialog-overlay">
   <template>
     <style include="lumo-overlay">
+      :host {
+        /* Optical centering */
+        --_lumo-dialog-transform: translateY(calc((-100vh + 100%) / 20));
+      }
+
       [part="overlay"] {
         box-shadow: 0 0 0 1px var(--lumo-shade-5pct), var(--lumo-box-shadow-xl);
         background-image: none;
         outline: none;
-        --_lumo-dialog-transform: translateY(calc((-100vh + 100%) / 20));
         transform: var(--_lumo-dialog-transform);
       }
 

--- a/theme/lumo/vaadin-dialog.html
+++ b/theme/lumo/vaadin-dialog.html
@@ -8,6 +8,8 @@
         box-shadow: 0 0 0 1px var(--lumo-shade-5pct), var(--lumo-box-shadow-xl);
         background-image: none;
         outline: none;
+        --_lumo-dialog-transform: translateY(calc((-100vh + 100%) / 20));
+        transform: var(--_lumo-dialog-transform);
       }
 
       [part="content"] {
@@ -28,7 +30,7 @@
       @keyframes vaadin-dialog-enter {
         0% {
           opacity: 0;
-          transform: scale(0.95);
+          transform: scale(0.95) var(--_lumo-dialog-transform);
         }
       }
 
@@ -43,7 +45,7 @@
       @keyframes vaadin-dialog-exit {
         100% {
           opacity: 0;
-          transform: scale(1.02);
+          transform: scale(1.02) var(--_lumo-dialog-transform);
         }
       }
     </style>


### PR DESCRIPTION
It’s a known optical illusion, that objects which are mathematically vertically centered appear to be lower than the center.

We can compensate for that by using a transform calculation that moves the dialog upwards by a certain ratio between the dialog height and viewport height. The magic number `20` was selected by “eyeballing” the results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog/70)
<!-- Reviewable:end -->
