### PR TITLE
Add default content minWidth to prevent collapsing to zero

### DIFF
--- a/src/vaadin-dialog.html
+++ b/src/vaadin-dialog.html
@@ -8,6 +8,20 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../vaadin-overlay/src/vaadin-overlay.html">
 <link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
 
+<dom-module id="vaadin-dialog-overlay-styles" theme-for="vaadin-dialog-overlay">
+  <template>
+    <style>
+      /*
+        NOTE(platosha): Make some min-width to prevent collapsing of the content
+        taking the parent width, e. g., <vaadin-grid> and such.
+      */
+      [part="content"] {
+        min-width: 12em; /* matches the default <vaadin-text-field> width */
+      }
+    </style>
+  </template>
+</dom-module>
+
 <dom-module id="vaadin-dialog">
   <template>
     <style>

--- a/test/vaadin-dialog_test.html
+++ b/test/vaadin-dialog_test.html
@@ -113,6 +113,12 @@
         const openDialog = () => dialog.opened = true;
         expect(openDialog).to.not.throw();
       });
+
+      it('should have min-width for content', () => {
+        dialog.opened = true;
+        const contentMinWidth = parseFloat(window.getComputedStyle(dialog.$.overlay.$.content).minWidth);
+        expect(contentMinWidth).to.be.gt(0);
+      });
     });
 
     describe('vaadin-dialog data binding', () => {


### PR DESCRIPTION
Fixes #76 
Connected to vaadin/vaadin-dialog-flow#70
Fixes vaadin/vaadin-dialog-flow#67

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog/77)
<!-- Reviewable:end -->
