### PR TITLE
feat: prepare for TS defs generation

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,22 @@
+export type DialogResizableDirection = 'n' | 'e' | 's' | 'w' | 'nw' | 'ne' | 'se' | 'sw';
+
+export type DialogResizeDimensions = {
+  width: string;
+  height: string;
+  contentWidth: string;
+  contentHeight: string;
+};
+
+export type DialogOverlayBounds = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+export type DialogOverlayBoundsParam = DialogOverlayBounds | {
+  top?: string | number;
+  left?: string | number;
+  width?: string | number;
+  height?: string | number;
+};

--- a/bower.json
+++ b/bower.json
@@ -27,16 +27,16 @@
   "dependencies": {
     "polymer": "^2.0.0",
     "iron-resizable-behavior": "^2.0.0",
-    "vaadin-overlay": "vaadin/vaadin-overlay#^3.4.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
+    "vaadin-overlay": "vaadin/vaadin-overlay#^3.5.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",
     "iron-test-helpers": "^2.0.0",
-    "vaadin-button": "vaadin/vaadin-button#^2.3.0",
+    "vaadin-button": "vaadin/vaadin-button#^2.4.0-alpha1",
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.1.0-alpha1"

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,20 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "@vaadin/vaadin-overlay/@types/interfaces": [
+      "OverlayRenderer"
+    ],
+    "./@types/interfaces": [
+      "DialogResizableDirection",
+      "DialogResizeDimensions",
+      "DialogOverlayBounds",
+      "DialogOverlayBoundsParam"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-dialog.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/src/vaadin-dialog-draggable-mixin.html
+++ b/src/vaadin-dialog-draggable-mixin.html
@@ -21,6 +21,7 @@
     class VaadinDialogDraggableMixin extends superClass {
       static get properties() {
         return {
+          /** @private */
           _touchDevice: {
             type: Boolean,
             value: TOUCH_DEVICE
@@ -28,6 +29,7 @@
         };
       }
 
+      /** @protected */
       ready() {
         super.ready();
         this._originalBounds = {};
@@ -39,6 +41,7 @@
         this.$.overlay.$.overlay.addEventListener('touchstart', this._startDrag);
       }
 
+      /** @private */
       _startDrag(e) {
         if (this.draggable && (e.button === 0 || e.touches)) {
           const resizerContainer = this.$.overlay.$.resizerContainer;
@@ -63,6 +66,7 @@
         }
       }
 
+      /** @private */
       _drag(e) {
         const event = this.__getMouseOrFirstTouchEvent(e);
         if (this._eventInWindow(event) &&
@@ -73,6 +77,7 @@
         }
       }
 
+      /** @private */
       _stopDrag() {
         window.removeEventListener('mouseup', this._stopDrag);
         window.removeEventListener('touchend', this._stopDrag);

--- a/src/vaadin-dialog-resizable-mixin.html
+++ b/src/vaadin-dialog-resizable-mixin.html
@@ -105,6 +105,7 @@
    */
   Vaadin.DialogResizableMixin = (superClass) =>
     class VaadinDialogResizableMixin extends superClass {
+      /** @protected */
       ready() {
         super.ready();
         this._originalBounds = {};
@@ -113,6 +114,7 @@
         this._addResizeListeners();
       }
 
+      /** @private */
       _addResizeListeners() {
         // Note: edge controls added before corners
         ['n', 'e', 's', 'w', 'nw', 'ne', 'se', 'sw'].forEach((direction) => {
@@ -131,6 +133,11 @@
         });
       }
 
+      /**
+       * @param {!MouseEvent | !TouchEvent} e
+       * @param {!DialogResizableDirection} direction
+       * @protected
+       */
       _startResize(e, direction) {
         if (e.button === 0 || e.touches) {
           e.preventDefault();
@@ -147,6 +154,11 @@
         }
       }
 
+      /**
+       * @param {!MouseEvent | !TouchEvent} e
+       * @param {!DialogResizableDirection} resizer
+       * @protected
+       */
       _resize(e, resizer) {
         const event = this.__getMouseOrFirstTouchEvent(e);
         if (this._eventInWindow(event) &&
@@ -190,6 +202,10 @@
         }
       }
 
+      /**
+       * @param {!DialogResizableDirection} direction
+       * @protected
+       */
       _stopResize(direction) {
         window.removeEventListener('mousemove', this._resizeListeners.resize[direction]);
         window.removeEventListener('touchmove', this._resizeListeners.resize[direction]);
@@ -198,6 +214,10 @@
         this.dispatchEvent(new CustomEvent('resize', {detail: this._getResizeDimensions()}));
       }
 
+      /**
+       * @return {!DialogResizeDimensions}
+       * @protected
+       */
       _getResizeDimensions() {
         const {width, height} = getComputedStyle(this.$.overlay.$.overlay);
         const content = this.$.overlay.$.content;

--- a/src/vaadin-dialog.html
+++ b/src/vaadin-dialog.html
@@ -153,8 +153,10 @@ This program is available under Apache License Version 2.0, available at https:/
        * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
        *
        * @memberof Vaadin
-       * @mixes Vaadin.ElementMixin
        * @mixes Vaadin.ThemePropertyMixin
+       * @mixes Vaadin.ElementMixin
+       * @mixes Vaadin.DialogDraggableMixin
+       * @mixes Vaadin.DialogResizableMixin
        * @demo demo/index.html
        */
       class DialogElement extends
@@ -175,6 +177,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * True if the overlay is currently displayed.
+             * @type {boolean}
              */
             opened: {
               type: Boolean,
@@ -184,6 +187,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to disable closing dialog on outside click
+             * @type {boolean}
              */
             noCloseOnOutsideClick: {
               type: Boolean,
@@ -192,6 +196,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to disable closing dialog on Escape press
+             * @type {boolean}
              */
             noCloseOnEsc: {
               type: Boolean,
@@ -213,6 +218,10 @@ This program is available under Apache License Version 2.0, available at https:/
              */
             theme: String,
 
+            /**
+             * @type {HTMLTemplateElement | undefined}
+             * @protected
+             */
             _contentTemplate: Object,
 
             /**
@@ -221,11 +230,13 @@ This program is available under Apache License Version 2.0, available at https:/
              *
              * - `root` The root container DOM element. Append your content to it.
              * - `dialog` The reference to the `<vaadin-dialog>` element.
+             * @type {OverlayRenderer | undefined}
              */
             renderer: Function,
 
             /**
              * Set to true to remove backdrop and allow click events on background elements.
+             * @type {boolean}
              */
             modeless: {
               type: Boolean,
@@ -238,6 +249,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * By default, only the overlay area can be used to drag the element. But,
              * a child element can be marked as a draggable area by adding a
              * "`draggable`" class to it.
+             * @type {boolean}
              */
             draggable: {
               type: Boolean,
@@ -247,6 +259,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to enable resizing the dialog by dragging the corners and edges.
+             * @type {boolean}
              */
             resizable: {
               type: Boolean,
@@ -254,8 +267,10 @@ This program is available under Apache License Version 2.0, available at https:/
               reflectToAttribute: true
             },
 
+            /** @private */
             _oldTemplate: Object,
 
+            /** @private */
             _oldRenderer: Object
           };
         }
@@ -268,6 +283,7 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
+        /** @protected */
         ready() {
           super.ready();
           this.$.overlay.setAttribute('role', 'dialog');
@@ -282,16 +298,22 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.overlay.$.content.addEventListener('touchmove', this._preventMove, {passive: false});
         }
 
+        /** @private */
         _preventMove(e) {
           if (e.touches.length < 2) {
             e.preventDefault();
           }
         }
 
+        /**
+         * @param {!Array<!Node>} nodes
+         * @protected
+         */
         _setTemplateFromNodes(nodes) {
           this._contentTemplate = nodes.filter(node => node.localName && node.localName === 'template')[0] || this._contentTemplate;
         }
 
+        /** @private */
         _removeNewRendererOrTemplate(template, oldTemplate, renderer, oldRenderer) {
           if (template !== oldTemplate) {
             this._contentTemplate = undefined;
@@ -307,6 +329,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.overlay.render();
         }
 
+        /** @private */
         _templateOrRendererChanged(template, renderer) {
           if (template && renderer) {
             this._removeNewRendererOrTemplate(template, this._oldTemplate, renderer, this._oldRenderer);
@@ -321,11 +344,13 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @protected */
         disconnectedCallback() {
           super.disconnectedCallback();
           this.opened = false;
         }
 
+        /** @private */
         _openedChanged(opened) {
           if (opened) {
             this.$.overlay.template = this.querySelector('template');
@@ -333,6 +358,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.overlay.opened = opened;
         }
 
+        /** @private */
         _ariaLabelChanged(ariaLabel) {
           if (ariaLabel !== undefined && ariaLabel !== null) {
             this.$.overlay.setAttribute('aria-label', ariaLabel);
@@ -341,6 +367,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _onOverlayOpened(e) {
           if (e.detail.value === false) {
             this.opened = false;
@@ -349,6 +376,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Close the dialog if `noCloseOnOutsideClick` isn't set to true
+         * @private
          */
         _handleOutsideClick(e) {
           if (this.noCloseOnOutsideClick) {
@@ -358,6 +386,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Close the dialog if `noCloseOnEsc` isn't set to true
+         * @private
          */
         _handleEscPress(e) {
           if (this.noCloseOnEsc) {
@@ -365,6 +394,10 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /**
+         * @param {!DialogOverlayBoundsParam} bounds
+         * @protected
+         */
         _setBounds(bounds) {
           const overlay = this.$.overlay.$.overlay;
           const parsedBounds = Object.assign({}, bounds);
@@ -383,12 +416,17 @@ This program is available under Apache License Version 2.0, available at https:/
           Object.assign(overlay.style, parsedBounds);
         }
 
+        /** @private */
         _bringOverlayToFront() {
           if (this.modeless) {
             this.$.overlay.bringToFront();
           }
         }
 
+        /**
+         * @return {!DialogOverlayBounds}
+         * @protected
+         */
         _getOverlayBounds() {
           const overlay = this.$.overlay.$.overlay;
           const overlayBounds = overlay.getBoundingClientRect();
@@ -400,10 +438,20 @@ This program is available under Apache License Version 2.0, available at https:/
           return {top, left, width, height};
         }
 
+        /**
+         * @param {!MouseEvent | !TouchEvent} e
+         * @return {boolean}
+         * @protected
+         */
         _eventInWindow(e) {
           return e.clientX >= 0 && e.clientX <= window.innerWidth && e.clientY >= 0 && e.clientY <= window.innerHeight;
         }
 
+        /**
+         * @param {!MouseEvent | !TouchEvent} e
+         * @return {!MouseEvent | !Touch}
+         * @protected
+         */
         __getMouseOrFirstTouchEvent(e) {
           return e.touches ? e.touches[0] : e;
         }

--- a/src/vaadin-dialog.html
+++ b/src/vaadin-dialog.html
@@ -214,11 +214,6 @@ This program is available under Apache License Version 2.0, available at https:/
             },
 
             /**
-             * Theme to apply to the overlay element
-             */
-            theme: String,
-
-            /**
              * @type {HTMLTemplateElement | undefined}
              * @protected
              */


### PR DESCRIPTION
Fixes #156

Generated TS definitions look like this:

### `vaadin-dialog.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {OverlayElement} from '@vaadin/vaadin-overlay/src/vaadin-overlay.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {ThemePropertyMixin} from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';

import {DialogDraggableMixin} from './vaadin-dialog-draggable-mixin.js';

import {DialogResizableMixin} from './vaadin-dialog-resizable-mixin.js';

import {IronResizableBehavior} from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';

import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class DialogElement extends
  ThemePropertyMixin(
  ElementMixin(
  DialogDraggableMixin(
  DialogResizableMixin(
  PolymerElement)))) {

  theme: string|null|undefined;
  opened: boolean;
  noCloseOnOutsideClick: boolean;
  noCloseOnEsc: boolean;
  ariaLabel: string|null|undefined;
  _contentTemplate: HTMLTemplateElement|null|undefined;
  renderer: OverlayRenderer|null|undefined;
  modeless: boolean;
  draggable: boolean;
  resizable: boolean;

  ready(): void;
  disconnectedCallback(): void;
  _setTemplateFromNodes(nodes: Node[]): void;
  render(): void;
  _setBounds(bounds: DialogOverlayBoundsParam): void;
  _getOverlayBounds(): DialogOverlayBounds;
  _eventInWindow(e: MouseEvent|TouchEvent): boolean;
  __getMouseOrFirstTouchEvent(e: MouseEvent|TouchEvent): MouseEvent|Touch;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-dialog": DialogElement;
  }
}

export {DialogElement};

import {OverlayRenderer} from '@vaadin/vaadin-overlay/@types/interfaces';

import {DialogOverlayBoundsParam} from '../@types/interfaces';

import {DialogOverlayBounds} from '../@types/interfaces';
```

### `vaadin-dialog-draggable-mixin.d.ts`

```ts
export {DialogDraggableMixin};

declare function DialogDraggableMixin<T extends new (...args: any[]) => {}>(base: T): T & DialogDraggableMixinConstructor;

interface DialogDraggableMixinConstructor {
  new(...args: any[]): DialogDraggableMixin;
}

export {DialogDraggableMixinConstructor};

interface DialogDraggableMixin {
  ready(): void;
}
```

### `vaadin-dialog-resizable-mixin.d.ts`

```ts
export {DialogResizableMixin};

declare function DialogResizableMixin<T extends new (...args: any[]) => {}>(base: T): T & DialogResizableMixinConstructor;

interface DialogResizableMixinConstructor {
  new(...args: any[]): DialogResizableMixin;
}

export {DialogResizableMixinConstructor};

interface DialogResizableMixin {
  ready(): void;
  _startResize(e: MouseEvent|TouchEvent, direction: DialogResizableDirection): void;
  _resize(e: MouseEvent|TouchEvent, resizer: DialogResizableDirection): void;
  _stopResize(direction: DialogResizableDirection): void;
  _getResizeDimensions(): DialogResizeDimensions;
}

import {DialogResizableDirection} from '../@types/interfaces';

import {DialogResizeDimensions} from '../@types/interfaces';
```

### `@types/interfaces.d.ts`

```ts
export type DialogResizableDirection = 'n' | 'e' | 's' | 'w' | 'nw' | 'ne' | 'se' | 'sw';

export type DialogResizeDimensions = {
  width: string;
  height: string;
  contentWidth: string;
  contentHeight: string;
};

export type DialogOverlayBounds = {
  top: number;
  left: number;
  width: number;
  height: number;
};

export type DialogOverlayBoundsParam = DialogOverlayBounds | {
  top?: string | number;
  left?: string | number;
  width?: string | number;
  height?: string | number;
};
```