### PR TITLE
fix: don't prevent touchmove events inside the dialog

### DIFF
--- a/src/vaadin-dialog-draggable-mixin.html
+++ b/src/vaadin-dialog-draggable-mixin.html
@@ -43,6 +43,11 @@
 
       /** @private */
       _startDrag(e) {
+        // Don't initiate when there's more than 1 touch (pinch zoom)
+        if (e.type === 'touchstart' && e.touches.length > 1) {
+          return;
+        }
+
         if (this.draggable && (e.button === 0 || e.touches)) {
           const resizerContainer = this.$.overlay.$.resizerContainer;
           const isResizerContainer = e.target === resizerContainer;
@@ -50,8 +55,7 @@
           const isContentPart = e.target === this.$.overlay.$.content;
           const isDraggable = e.target.classList.contains('draggable');
           if ((isResizerContainer && !isResizerContainerScrollbar) || isContentPart || isDraggable) {
-            // Is needed to prevent text selection in Safari
-            !this._touchDevice && !isDraggable && e.preventDefault();
+            !isDraggable && e.preventDefault();
             this._originalBounds = this._getOverlayBounds();
             const event = this.__getMouseOrFirstTouchEvent(e);
             this._originalMouseCoords = {top: event.pageY, left: event.pageX};
@@ -69,8 +73,7 @@
       /** @private */
       _drag(e) {
         const event = this.__getMouseOrFirstTouchEvent(e);
-        if (this._eventInWindow(event) &&
-          (e.type !== 'touchmove' || e.type === 'touchmove' && e.touches.length < 2)) {
+        if (this._eventInWindow(event)) {
           const top = this._originalBounds.top + (event.pageY - this._originalMouseCoords.top);
           const left = this._originalBounds.left + (event.pageX - this._originalMouseCoords.left);
           this._setBounds({top, left});

--- a/src/vaadin-dialog-resizable-mixin.html
+++ b/src/vaadin-dialog-resizable-mixin.html
@@ -139,6 +139,11 @@
        * @protected
        */
       _startResize(e, direction) {
+        // Don't initiate when there's more than 1 touch (pinch zoom)
+        if (e.type === 'touchstart' && e.touches.length > 1) {
+          return;
+        }
+
         if (e.button === 0 || e.touches) {
           e.preventDefault();
           this._originalBounds = this._getOverlayBounds();
@@ -161,8 +166,7 @@
        */
       _resize(e, resizer) {
         const event = this.__getMouseOrFirstTouchEvent(e);
-        if (this._eventInWindow(event) &&
-          (e.type !== 'touchmove' || e.type === 'touchmove' && e.touches.length < 2)) {
+        if (this._eventInWindow(event)) {
           const minimumSize = 40;
           resizer.split('').forEach((direction) => {
             switch (direction) {

--- a/src/vaadin-dialog.html
+++ b/src/vaadin-dialog.html
@@ -288,16 +288,6 @@ This program is available under Apache License Version 2.0, available at https:/
           this._observer = new Polymer.FlattenedNodesObserver(this, info => {
             this._setTemplateFromNodes(info.addedNodes);
           });
-
-          // We need to prevent dragging behind the non-draggable content of the dialog (i.e slotted text / button)
-          this.$.overlay.$.content.addEventListener('touchmove', this._preventMove, {passive: false});
-        }
-
-        /** @private */
-        _preventMove(e) {
-          if (e.touches.length < 2) {
-            e.preventDefault();
-          }
         }
 
         /**

--- a/test/vaadin-dialog_draggable-resizable-test.html
+++ b/test/vaadin-dialog_draggable-resizable-test.html
@@ -558,6 +558,11 @@
           expect(e.defaultPrevented).to.be.true;
         });
 
+        it('should not prevent default of the touchmove events', () => {
+          const e = dispatchTouchEvent(draggableOverlay.$.content, 'touchmove');
+          expect(e.defaultPrevented).to.be.false;
+        });
+
         it('should bring to front on touch start', () => {
           dispatchTouchEvent(resizableContainer, 'touchstart');
           expect(getFrontmostOverlayFromScreenCenter()).to.equal(resizableOverlay);

--- a/test/vaadin-dialog_draggable-resizable-test.html
+++ b/test/vaadin-dialog_draggable-resizable-test.html
@@ -512,7 +512,7 @@
             y: Math.floor(bounds.top + (bounds.height / 2))
           };
           const toXY = {x: fromXY.x + dx, y: fromXY.y + dx};
-          dispatchTouchEvent(target, 'touchstart', fromXY);
+          dispatchTouchEvent(target, 'touchstart', fromXY, multitouch);
           dispatchTouchEvent(target, 'touchmove', toXY, multitouch);
           dispatchTouchEvent(target, 'touchend', toXY);
         }
@@ -525,7 +525,7 @@
           };
 
           const toXY = {x: fromXY.x + dx, y: fromXY.y + dy};
-          dispatchTouchEvent(target, 'touchstart', fromXY);
+          dispatchTouchEvent(target, 'touchstart', fromXY, multitouch);
           dispatchTouchEvent(target, 'touchmove', toXY, multitouch);
           dispatchTouchEvent(target, 'touchend', toXY);
         }
@@ -555,11 +555,6 @@
         it('should prevent default of the touchstart when dragged on desktop', () => {
           draggable._touchDevice = false;
           const e = dispatchTouchEvent(draggableOverlay.$.content, 'touchstart');
-          expect(e.defaultPrevented).to.be.true;
-        });
-
-        it('should prevent default of the touchmove when dragged', () => {
-          const e = dispatchTouchEvent(draggableOverlay.$.content, 'touchmove');
           expect(e.defaultPrevented).to.be.true;
         });
 


### PR DESCRIPTION
Fixes #161 

The previous logic tried to prevent scrolling the document on the background by canceling all touchmove events. This PR reverts the change, which means that the document is again scrollable in case the touch sequence starts over non-draggable/non-scrollable dialog content. This, however, is a much lesser evil than not being able to scroll the dialog content at all on a touch device.