### PR TITLE
fix: prevent incorrect overflow in Safari

### DIFF
--- a/src/vaadin-dialog-resizable-mixin.html
+++ b/src/vaadin-dialog-resizable-mixin.html
@@ -19,7 +19,7 @@
       }
 
       [part='overlay'][style] .resizer-container {
-        height: 100%;
+        min-height: 100%;
         width: 100%;
       }
 

--- a/test/vaadin-dialog_draggable-resizable-test.html
+++ b/test/vaadin-dialog_draggable-resizable-test.html
@@ -79,6 +79,15 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="overflow">
+    <template>
+      <vaadin-dialog draggable opened modeless>
+        <template>
+        </template>
+      </vaadin-dialog>
+    </template>
+  </test-fixture>
+
   <script>
       function dispatchMouseEvent(target, type, coords = {x: 0, y: 0}, button = 0) {
         const e = new MouseEvent(type, {
@@ -726,6 +735,26 @@
           actualTextContent = document.elementFromPoint(windowCenterWidth, windowCenterHeight).innerText.trim();
           expect(actualTextContent).to.be.eql(expectedTextContent);
           expect(modalDialog.opened).to.be.true;
+        });
+      });
+
+      describe('dialog with overflowing content', () => {
+        let dialog;
+
+        beforeEach(() => {
+          dialog = fixture('overflow');
+        });
+
+        it('should not overflow when style attribute is set on the overlay part', () => {
+          const container = document.createElement('div');
+          container.style.maxWidth = '300px';
+          container.style.overflow = 'auto';
+          container.textContent = Array(100).join('Lorem ipsum dolor sit amet');
+          const overlay = dialog.$.overlay;
+          overlay.content.appendChild(container);
+          // emulate removing "pointer-events: none"
+          overlay.$.overlay.setAttribute('style', '');
+          expect(overlay.$.overlay.offsetHeight).to.equal(overlay.$.resizerContainer.offsetHeight);
         });
       });
   </script>


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-dialog-flow/issues/204

See the description of the actual Safari issue here: https://github.com/vaadin/vaadin-dialog-flow/issues/204#issuecomment-661874922
The fix can be tested with the demo: https://github.com/vaadin/vaadin-dialog-flow/commit/576c1405bc95ceba2d7dcffaff68d1045d23e739

This should not re-introduce regression from #172 because `min-height` is set on the different element.