### PR TITLE
refactor: move how overlay max-width is set

### DIFF
--- a/src/vaadin-dialog.html
+++ b/src/vaadin-dialog.html
@@ -24,6 +24,10 @@ This program is available under Apache License Version 2.0, available at https:/
       [part="content"] {
         min-width: 12em; /* matches the default <vaadin-text-field> width */
       }
+
+      :host([has-bounds-set]) [part="overlay"] {
+        max-width: none;
+      }
     </style>
   </template>
 </dom-module>
@@ -391,7 +395,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           if (overlay.style.position !== 'absolute') {
             overlay.style.position = 'absolute';
-            overlay.style.maxWidth = 'none';
+            this.$.overlay.setAttribute('has-bounds-set', '');
             this.__forceSafariReflow();
           }
 


### PR DESCRIPTION
Instead of setting `max-width: none` when a dialog is dragged or resized directly to the node style attribute, use a custom attribute which is used in a CSS selector to apply that style. It will prevent a custom `max-width` from being reset when user resizes or drags the dialog.

Part of https://github.com/vaadin/vaadin-dialog-flow/issues/168